### PR TITLE
Filtering params on Tastypie resources

### DIFF
--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -99,7 +99,7 @@ class ResourceSwaggerMapping(object):
             'parameters': self.build_parameters_from_filters(),
             'responseClass': 'List',
             'nickname': '%s-list' % self.resource_name,
-            }
+        }
 
     def build_detail_api(self):
         detail_api = {


### PR DESCRIPTION
This patch introduces the ability to show fields to filter by according to the "filtering" meta option added to your Tastypie Resources on list operations.

It loops through all of the fields configured in "filtering" and checks if they're valid as well as following through to related model instances.

Would love to hear some feedback on what you think.
