### PR TITLE
Keep support for Django < 1.5

### DIFF
--- a/tastypie_swagger/templates/tastypie_swagger/index.html
+++ b/tastypie_swagger/templates/tastypie_swagger/index.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
Please stay backward compatible. A new release for Django 1.5 would be nice.
