### PR TITLE
Fixed backwards compatibility Django < 1.5 in the Template

### DIFF
--- a/tastypie_swagger/templates/tastypie_swagger/index.html
+++ b/tastypie_swagger/templates/tastypie_swagger/index.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
Load for the earlier version of Django the "url from future" library
Fixed #26 
