### PR TITLE
Building parameters from filtering fields when field is not using ALL or ALL_WITH_RELATIONS, fails when a tuple is used instead of a list

### DIFF
--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -4,7 +4,7 @@ from django.db.models.sql.constants import QUERY_TERMS
 from django.utils.encoding import force_unicode
 from tastypie import fields
 
-from .utils import trailing_slash_or_none, urljoin_forced
+from .utils import trailing_slash_or_none, urljoin_forced, is_sequence
 
 
 # Ignored POST fields
@@ -91,7 +91,7 @@ class ResourceSwaggerMapping(object):
 #            parameter.update({'allowableValues': allowed_values})
         return parameter
 
-    def build_parameters_from_fields(self):   
+    def build_parameters_from_fields(self):
         parameters = []
         for name, field in self.schema['fields'].items():
             # Ignore readonly fields
@@ -176,7 +176,7 @@ class ResourceSwaggerMapping(object):
                         related_mapping = ResourceSwaggerMapping(related_resource)
                         parameters.extend(related_mapping.build_parameters_from_filters(prefix="%s%s__" % (prefix, name)))
 
-                if isinstance( field, list ):
+                elif is_sequence(field):
                     # Skip if this is an incorrect filter
                     if name not in self.schema['fields']: continue
 

--- a/tastypie_swagger/utils.py
+++ b/tastypie_swagger/utils.py
@@ -18,3 +18,12 @@ def urljoin_forced(base, path, **kwargs):
     """
     base = base.endswith('/') and base or '%s/' % base
     return urljoin(base, path, **kwargs)
+
+
+def is_sequence(arg):
+    """
+    Check if arg is a sequence
+    """
+    return (not hasattr(arg, "strip") and
+            hasattr(arg, "__getitem__") or
+            hasattr(arg, "__iter__"))


### PR DESCRIPTION
A resource with this filtering attribute, is valid for tastypie:

``` python
       filtering = {
            "session_number": ('exact',),
            "number": ('exact',),
            "member": ('exact', ),
            "date": ALL
        }
```

But the mapper fails building those fields because is expecting the value ALL, ALL_WITH_RELATIONS or a list type. 

`is_sequence` will check for any valid sequence type.
