### PR TITLE
Add support for markdown parsing of docstring.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,7 @@ This package provides two things:
 
 1. An embedded instance of `Swagger UI`_ to point a URL to.
 2. Automatic `Resource Listing`_ and `API Declaration`_ generation that is consumed by #1
+3. Markdown parsing of Resource docstrings using `misaka`_
 
 
 Usage
@@ -61,3 +62,4 @@ You can use `this ModelResource subclass <https://gist.github.com/4041352>`_ as 
 .. _API Declaration: https://github.com/wordnik/swagger-core/wiki/API-Declaration
 .. _Swagger UI: https://github.com/wordnik/swagger-ui
 .. _tastypie.api.Api: https://django-tastypie.readthedocs.org/en/latest/api.html
+.. _misaka: https://github.com/FSX/misaka

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     long_description=longdesc,
     author='Concentric Sky',
     author_email='code@concentricsky.com',
+    install_requires = ['misaka==1.0.2'],
     classifiers=[
         'Programming Language :: Python',
         'Environment :: Web Environment',

--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -1,4 +1,6 @@
 import datetime
+import inspect
+import misaka as markdownrender
 from django.core.urlresolvers import reverse
 from django.db.models.sql.constants import QUERY_TERMS
 from django.utils.encoding import force_unicode
@@ -91,7 +93,7 @@ class ResourceSwaggerMapping(object):
 #            parameter.update({'allowableValues': allowed_values})
         return parameter
 
-    def build_parameters_from_fields(self):   
+    def build_parameters_from_fields(self):
         parameters = []
         for name, field in self.schema['fields'].items():
             # Ignore readonly fields
@@ -244,7 +246,7 @@ class ResourceSwaggerMapping(object):
             'parameters': [self.build_parameter(paramType='path', name=self._detail_uri_name(), dataType='int', description='ID of resource')],
             'responseClass': self.resource_name,
             'nickname': '%s-detail' % self.resource_name,
-            'notes': self.resource.__doc__,
+            'notes': markdownrender.html(inspect.getdoc(self.resource)),
         }
         return operation
 
@@ -255,7 +257,7 @@ class ResourceSwaggerMapping(object):
             'parameters': self.build_parameters_for_list(method=method),
             'responseClass': 'ListView' if method.upper() == 'GET' else self.resource_name,
             'nickname': '%s-list' % self.resource_name,
-            'notes': self.resource.__doc__,
+            'notes': markdownrender.html(inspect.getdoc(self.resource)),
         }
 
     def build_extra_operation(self, extra_action):


### PR DESCRIPTION
- Markdown parsing using [misaka](https://github.com/FSX/misaka) that supports github
  flavoured syntax.
- use inspect.getdoc to clean up the whitespaces.

Signed-off-by: Saurabh Kumar thes.kumar@gmail.com
