### PR TITLE
Added list view possibility to mapping.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,7 @@ called ``extra_actions``. Following the Tastypie search example, here is how
                 "name": "search",
                 "http_method": "GET",
                 "resource_type": "list",
+                "description": "Seach endpoint",
                 "fields": {
                     "q": {
                         "type": "string",
@@ -74,6 +75,41 @@ called ``extra_actions``. Following the Tastypie search example, here is how
             }
         ]
 
+``extra_actions`` is a list of dictionary objects that define extra endpoints
+that are unavailable to introspection.
+
+.. important::
+   ``extra_actions`` feeds directly into the schema **for swagger**. It does
+   not alter the tastypie schema listing tastypie provides.
+
+Top level keys and meaning in the ``extra_actions`` dictionary:
+
+- ``name``: **Required**. Nickname of the resource.
+- ``http_method``: Defaults to ``"GET"``. HTTP method allowed here as a string.
+  Will be uppercased on output.
+- ``resource_type``: If this is declared as ``"list"`` then the endpoint
+  **will not** include a ``{id}`` parameter in the uri or in the parameters
+  list. This is applicable to endpoints such as the above example that filter
+  or perform actions across many items. If ``resource_type`` is ommitted and
+  the ``http_method`` is ``"GET"`` then the endpoint will default to ``"view"``
+  and include a ``{id}`` parameter in the uri and parameter list.
+- ``description``: Description of this endpoint.
+- ``fields``: Dictionary of parameters this endpoint accepts.
+
+Field dictionaries are declared in a ``{ "name": { [options dict] }`` style.
+This is done for compatability reasons with older versions of
+django-tastypie-swagger.
+
+.. warning::
+   The structure of ``fields`` will likely change in future versions if
+   `Joshua Kehn`_ continues committing.
+
+Available keys and meaning for the ``fields`` dictionary.::
+
+ - ``type``: Defaults to ``"string"``. Parameter type.
+ - ``required``: Defaults to ``False``.
+ - ``description``: Defaults to ``""`` (empty string). Description of this
+   parameter.
 
 
 Detecting required fields
@@ -93,3 +129,4 @@ You can use `this ModelResource subclass <https://gist.github.com/4041352>`_ as 
 .. _API Declaration: https://github.com/wordnik/swagger-core/wiki/API-Declaration
 .. _Swagger UI: https://github.com/wordnik/swagger-ui
 .. _tastypie.api.Api: https://django-tastypie.readthedocs.org/en/latest/api.html
+.. _Joshua Kehn: mailto:josh@kehn.us

--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -224,15 +224,18 @@ class ResourceSwaggerMapping(object):
 
     def build_parameters_from_extra_action(self, method, fields, resource_type):
         parameters = []
-        if method.upper() == 'GET' and resource_type == "view":
-            parameters.append(self.build_parameter(paramType='path', name=self._detail_uri_name(), dataType='int', description='ID of resource'))
+        if method.upper() == 'GET' or resource_type == "view":
+            parameters.append(self.build_parameter(paramType='path',
+                name=self._detail_uri_name(),
+                dataType='int',
+                description='ID of resource'))
         for name, field in fields.items():
             parameters.append(self.build_parameter(
                 paramType="query",
                 name=name,
-                dataType=field['type'],
-                required=field['required'],
-                description=force_unicode(field['description']),
+                dataType=field.get("type", "string"),
+                required=field.get("required", True),
+                description=force_unicode(field.get("description", "")),
             ))
 
         return parameters
@@ -259,8 +262,11 @@ class ResourceSwaggerMapping(object):
         }
 
     def build_extra_operation(self, extra_action):
+        if "name" not in extra_action:
+            raise LookupError("\"name\" is a required field in extra_actions.")
         return {
-            'httpMethod': extra_action['http_method'].upper(),
+            'summary': extra_action.get("summary", ""),
+            'httpMethod': extra_action.get('http_method', "get").upper(),
             'parameters': self.build_parameters_from_extra_action(
                 method=extra_action.get('http_method'),
                 fields=extra_action.get('fields'),


### PR DESCRIPTION
This pull request should resolve issue #25 as well. Documentation has been updated as to the `extra_actions` attribute. The `mapping.py` file has the bulk of the changes built around allowing endpoints to be included from `extra_actions` without them needing to require a primary key.
