### PR TITLE
fix for Version not showing on index page, fixed typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,8 +35,6 @@ Add to INSTALLED_APPS::
         ...
     ]
 
-    VERSION = '0.1'
-
 Enable documentation for an api endpoint by adding a URL to your urlpatterns.
 
 eg::
@@ -178,7 +176,3 @@ For nearly a decade, Concentric Sky has been building technology solutions that 
 
 .. toctree::
    :maxdepth: 2
-
-
-
-

--- a/tastypie_swagger/views.py
+++ b/tastypie_swagger/views.py
@@ -1,7 +1,6 @@
 import sys
 import json
 
-from django.conf import settings
 from django.views.generic import TemplateView
 from django.http import HttpResponse, Http404
 from django.core.exceptions import ImproperlyConfigured


### PR DESCRIPTION
With this small fix, "version" on bottom of the index page is taken directly from "VERSION" variable in "settings.py", otherwise "unknown" is shown.
