### PR TITLE
Added resourcePath as per Swagger spec

### DIFF
--- a/tastypie_swagger/views.py
+++ b/tastypie_swagger/views.py
@@ -137,6 +137,6 @@ class SchemaView(TastypieApiMixin, SwaggerApiDataMixin, JSONView):
             'basePath': '/',
             'apis': mapping.build_apis(),
             'models': mapping.build_models(),
-            'resourcePath': '/%s.{format}' % resource._meta.resource_name
+            'resourcePath': '/{0}'.format(resource._meta.resource_name)
         })
         return context


### PR DESCRIPTION
Hi, making this pull request because swagger-codegen gets upset when resourcePath isn't included within the schema
