### PR TITLE
Changed nicknames to be swagger-codegen friendly

### DIFF
--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -297,7 +297,7 @@ class ResourceSwaggerMapping(object):
                 ),
             ],
             'responseClass': self.resource_name,
-            'nickname': '%s-detail' % self.resource_name,
+            'nickname': '%s_detail' % self.resource_name,
             'notes': self.resource.__doc__,
         }
         return operation
@@ -308,7 +308,7 @@ class ResourceSwaggerMapping(object):
             'httpMethod': method.upper(),
             'parameters': self.build_parameters_for_list(method=method),
             'responseClass': 'ListView' if method.upper() == 'GET' else self.resource_name,
-            'nickname': '%s-list' % self.resource_name,
+            'nickname': '%s_list' % self.resource_name,
             'notes': self.resource.__doc__,
         }
 


### PR DESCRIPTION
Hi, swagger-codegen uses the nickname to name generated functions. Because the nicknames include a "-" this leads to the generated functions causing a syntax error in the generated Python code.

Eg. Notice the dash between fooname and list:
def fooname-list(self, **kwargs):

This PR makes the nicknames swagger-codegen friendly.
