### PR TITLE
Prevent KeyError when popping 'tastypie_api_module' from context

### DIFF
--- a/tastypie_swagger/views.py
+++ b/tastypie_swagger/views.py
@@ -70,7 +70,7 @@ class JSONView(TemplateView):
         """
 
         # This cannot be serialized if it is a api instance and we don't need it anyway.
-        context.pop('tastypie_api_module')
+        context.pop('tastypie_api_module', None)
 
         for k in ['params','view']:
             if k in context:


### PR DESCRIPTION
For some reason `tastypie_api_module` didn't exist in the template context. Maybe it's because we're still using Django 1.4.5 (yes, we're aware of the security updates ;))

```
Traceback (most recent call last):
  File "/home/vagrant/envs/vagrant/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/home/vagrant/envs/vagrant/local/lib/python2.7/site-packages/django/views/generic/base.py", line 48, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/vagrant/envs/vagrant/local/lib/python2.7/site-packages/django/views/generic/base.py", line 69, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/vagrant/envs/vagrant/local/lib/python2.7/site-packages/django/views/generic/base.py", line 124, in get
    return self.render_to_response(context)
  File "/home/vagrant/webhire/tastypie_swagger/views.py", line 73, in render_to_response
    context.pop('tastypie_api_module')
KeyError: 'tastypie_api_module'
```

I've put the `tastypie_swagger` module in my project directory (`/home/vagrant/webhire`) to be able to debug it.
