### PR TITLE
Changing params to the intended kwargs value used in the url parameter

### DIFF
--- a/tastypie_swagger/views.py
+++ b/tastypie_swagger/views.py
@@ -52,7 +52,7 @@ class SwaggerApiDataMixin(object):
     def get_context_data(self, *args, **kwargs):
         context = super(SwaggerApiDataMixin, self).get_context_data(*args, **kwargs)
         context.update({
-            'apiVersion': context['params'].get('version', 'Unknown'),
+            'apiVersion': self.kwargs.get('version', 'Unknown'),
             'swaggerVersion': '1.1',
         })
         return context


### PR DESCRIPTION
Otherwise one will get the following:

```
[2014-07-28 22:52:38,389: ERROR/MainProcess] - django.request - Internal Server Error: /api/v1/doc/resources/
Traceback (most recent call last):
  File "/Users/dev/.virtualenvs/tps-env/lib/python2.7/site-packages/django/core/handlers/base.py", line 114, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/dev/.virtualenvs/tps-env/lib/python2.7/site-packages/django/views/generic/base.py", line 69, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/dev/.virtualenvs/tps-env/lib/python2.7/site-packages/django/views/generic/base.py", line 87, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/dev/.virtualenvs/tps-env/lib/python2.7/site-packages/django/views/generic/base.py", line 154, in get
    context = self.get_context_data(**kwargs)
  File "/Users/dev/.virtualenvs/tps-env/lib/python2.7/site-packages/tastypie_swagger/views.py", line 107, in get_context_data
    context = super(ResourcesView, self).get_context_data(*args, **kwargs)
  File "/Users/dev/.virtualenvs/tps-env/lib/python2.7/site-packages/tastypie_swagger/views.py", line 55, in get_context_data
    'apiVersion': context['params'].get('version', 'Unknown'),
KeyError: 'params'
```
