### PR TITLE
fix import paths and names for python 3 compliance

### DIFF
--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 
 from django.db.models.sql.constants import QUERY_TERMS
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text as force_unicode
 
 from tastypie import fields
 

--- a/tastypie_swagger/utils.py
+++ b/tastypie_swagger/utils.py
@@ -1,4 +1,4 @@
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 from django.conf import settings
 


### PR DESCRIPTION
These are changes that I have had to make to this app to have it work with python >=3. 