### PR TITLE
Update urls.py

### DIFF
--- a/tastypie_swagger/urls.py
+++ b/tastypie_swagger/urls.py
@@ -8,6 +8,6 @@ from .views import SwaggerView, ResourcesView, SchemaView
 urlpatterns = patterns('',
     url(r'^$', SwaggerView.as_view(), name='index'),
     url(r'^resources/$', ResourcesView.as_view(), name='resources'),
-    url(r'^schema/(?P<resource>\S+)/$', SchemaView.as_view()),
+    url(r'^schema/(?P<resource>\S+)$', SchemaView.as_view()),
     url(r'^schema/$', SchemaView.as_view(), name='schema'),
 )


### PR DESCRIPTION
Removed trailing slash to resolve tastypie endpoints correctly (not relying on append slash/middleware).
See issue https://github.com/concentricsky/django-tastypie-swagger/issues/89