### PR TITLE
Added simple support for allow custom_filtering

### DIFF
--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -179,11 +179,11 @@ class ResourceSwaggerMapping(object):
                 ('limit', 'int', 'Specify the number of element to display per page.'),
                 ('offset', 'int', 'Specify the offset to start displaying element on a page.'),
             ]
-            for name, type, desc in navigation_filters:
+            for name, data_type, desc in navigation_filters:
                 parameters.append(self.build_parameter(
                     paramType="query",
                     name=name,
-                    dataType=type,
+                    dataType=data_type,
                     required=False,
                     description=force_text(desc),
                 ))
@@ -261,6 +261,17 @@ class ResourceSwaggerMapping(object):
                                     description=force_text(schema_field['help_text']),
                                 ))
 
+        # custom filtering
+        custom_filtering = getattr(self.resource.Meta, 'custom_filtering', None)
+        if type(custom_filtering) == dict:
+            for key, value in custom_filtering.iteritems():
+                parameters.append(self.build_parameter(
+                    paramType="query",
+                    name=key,
+                    dataType=value['dataType'],
+                    required=value['required'],
+                    description=value['description'],
+                ))
         return parameters
 
     def build_parameter_for_object(self, method='get'):


### PR DESCRIPTION
In some cases we need to add custom filtering to our tastypie resources, but without adding to Resource.Meta.filtering. With this PR you can add all custom filtering to Resource.Meta class in format as the following: 
custom_filtering = {
            'custom_field': {
                'dataType': 'string',
                'required': False,
                'description': 'Filtering custom field'
            },
}