### PR TITLE
Improvment - Addition of custom model via extra-action

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -115,21 +115,23 @@ Top level keys and meaning in the ``extra_actions`` dictionary:
   and include a ``{id}`` parameter in the uri and parameter list.
 - ``summary``: Description of this endpoint.
 - ``fields``: **Optional** Dictionary of parameters this endpoint accepts.
-- ``responseClass``: **Optional** Should correspond to the id of the corresponding model
-- ``model``: **Optional** Dictionary of parameters describing the model. ``type`` and ``description`` are the two required elements.
+- ``responseClass``: **Optional** Should match the id of the corresponding model
+- ``model``: **Optional** Dictionary of parameters describing the model. ``type`` and ``description`` are the two required elements.  ``required`` is optional and is False by default.
 Example ::
 
-	'responseClass': 'video_managment',
+	'responseClass': 'blog-class',
 	'model':{
-		'id': "blog",
+		'id': "blog-class",
 		"properties": {
 			"title": {
 				"type": "string",
-				"description": ""
+				"description": "This is the title. Max 80 caracters."
+				"required":True
 			},
 			"content": {
 				"type": "text",
-				"description": "Some text"
+				"description": "Content of your post. Text up to 65000+"
+				"required":True
 			}
 		}
 	}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -115,6 +115,24 @@ Top level keys and meaning in the ``extra_actions`` dictionary:
   and include a ``{id}`` parameter in the uri and parameter list.
 - ``summary``: Description of this endpoint.
 - ``fields``: **Optional** Dictionary of parameters this endpoint accepts.
+- ``responseClass``: **Optional** Should correspond to the id of the corresponding model
+- ``model``: **Optional** Dictionary of parameters describing the model. ``type`` and ``description`` are the two required elements.
+Example ::
+
+	'responseClass': 'video_managment',
+	'model':{
+		'id': "blog",
+		"properties": {
+			"title": {
+				"type": "string",
+				"description": ""
+			},
+			"content": {
+				"type": "text",
+				"description": "Some text"
+			}
+		}
+	}
 
 Field dictionaries are declared in a ``{ "name": { [options dict] }`` style.
 This is done for compatibility reasons with older versions of

--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -349,7 +349,7 @@ class ResourceSwaggerMapping(object):
                 # is not set.
                 fields=extra_action.get('fields', {}),
                 resource_type=extra_action.get("resource_type", "view")),
-            'responseClass': 'Object', #TODO this should be extended to allow the creation of a custom object.
+            'responseClass': extra_action.get("responseClass", "Object"),
             'nickname': extra_action['name'],
             'notes': extra_action.get('notes', ''),
         }
@@ -527,7 +527,6 @@ class ResourceSwaggerMapping(object):
         return models
 
     def build_models(self):
-        #TODO this should be extended to allow the creation of a custom objects for extra_actions.
         models = {}
 
         # Take care of the list particular schema with meta and so on.
@@ -560,4 +559,16 @@ class ResourceSwaggerMapping(object):
                 id=self.resource_name
             )
         )
+
+        if hasattr(self.resource._meta, 'extra_actions'):
+            for extra_action in self.resource._meta.extra_actions:
+                if "model" in extra_action:
+                    models.update(
+                        self.build_model(
+                        resource_name=extra_action['model']['id'],
+                        properties=extra_action['model']['properties'],
+                        id=extra_action['model']['id']
+                        )
+                    )
+
         return models

--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -123,6 +123,7 @@ class ResourceSwaggerMapping(object):
             'description': description,
         }
 
+
         # TODO make use of this to Implement the allowable_values of swagger
         # (https://github.com/wordnik/swagger-core/wiki/Datatypes) at the field level.
         # This could be added to the meta value of the resource to specify enum-like or range data on a field.
@@ -138,7 +139,7 @@ class ResourceSwaggerMapping(object):
                 parameters.append(self.build_parameter(
                     name=name,
                     dataType=field['type'],
-                    required=not field['blank'],
+                    required=field['nullable'],
                     description=force_text(field['help_text']),
                 ))
         return parameters
@@ -412,14 +413,14 @@ class ResourceSwaggerMapping(object):
         apis.extend(self.build_extra_apis())
         return apis
 
-    def build_property(self, name, type, description=""):
+    def build_property(self, name, type, description="", required=False):
         prop = {
             name: {
                 'type': type,
                 'description': description,
+                'required':required
             }
         }
-
         if type == 'List':
             prop[name]['items'] = {'$ref': name}
 
@@ -449,6 +450,7 @@ class ResourceSwaggerMapping(object):
                     # note: 'help_text' is a Django proxy which must be wrapped
                     # in unicode *specifically* to get the actual help text.
                     force_text(field.get('help_text', '')),
+                    field.get('nullable')
                 )
             )
         return properties


### PR DESCRIPTION
I modified two places in the document: Around line 352 so that a two
news extra_actions elements are available : "responseClass"  as well as
"model" in order to allow the user to define custom model for his custom
endpoints.
The other modification is on line 563+ to add the custom model onto the
modellist.

This is my first commit / pull request ever. So let me know if I should do this differently. Thanks!