### PR TITLE
fix for issue #112

### DIFF
--- a/tastypie_swagger/templates/tastypie_swagger/index.html
+++ b/tastypie_swagger/templates/tastypie_swagger/index.html
@@ -1,23 +1,22 @@
-{% load url from future %}
-
+{% load staticfiles %}
 <!DOCTYPE html>
 <html>
 <head>
     <title>Swagger UI</title>
     <link href='https://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'/>
-    <link href='{{ STATIC_URL }}tastypie_swagger/css/highlight.default.css' media='screen' rel='stylesheet' type='text/css'/>
-    <link href='{{ STATIC_URL }}tastypie_swagger/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-    <script type="text/javascript" src="{{ STATIC_URL }}tastypie_swagger/js/lib/shred.bundle.js"></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/lib/jquery.slideto.min.js' type='text/javascript'></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/lib/jquery.wiggle.min.js' type='text/javascript'></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/lib/handlebars-1.0.0.js' type='text/javascript'></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/lib/underscore-min.js' type='text/javascript'></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/lib/backbone-min.js' type='text/javascript'></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/lib/swagger.js' type='text/javascript'></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/swagger-ui.js' type='text/javascript'></script>
-    <script src='{{ STATIC_URL }}tastypie_swagger/js/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+    <link href='{% static "tastypie_swagger/css/highlight.default.css" %}' media='screen' rel='stylesheet' type='text/css'/>
+    <link href='{% static "tastypie_swagger/css/screen.css" %}' media='screen' rel='stylesheet' type='text/css'/>
+    <script type="text/javascript" src="{% static "tastypie_swagger/js/lib/shred.bundle.js" %}"></script>
+    <script src='{% static "tastypie_swagger/js/lib/jquery-1.8.0.min.js" %}' type='text/javascript'></script>
+    <script src='{% static "tastypie_swagger/js/lib/jquery.slideto.min.js" %}' type='text/javascript'></script>
+    <script src='{% static "tastypie_swagger/js/lib/jquery.wiggle.min.js" %}' type='text/javascript'></script>
+    <script src='{% static "tastypie_swagger/js/lib/jquery.ba-bbq.min.js" %}' type='text/javascript'></script>
+    <script src='{% static "tastypie_swagger/js/lib/handlebars-1.0.0.js" %}' type='text/javascript'></script>
+    <script src='{% static "tastypie_swagger/js/lib/underscore-min.js" %}' type='text/javascript'></script>
+    <script src='{% static "tastypie_swagger/js/lib/backbone-min.js" %}' type='text/javascript'></script>
+    <script src='{% static "tastypie_swagger/js/lib/swagger.js" %}' type='text/javascript'></script>
+    <script src='{% static "tastypie_swagger/js/swagger-ui.js" %}' type='text/javascript'></script>
+    <script src='{% static "tastypie_swagger/js/lib/highlight.7.3.pack.js" %}' type='text/javascript'></script>
 
     <style type="text/css">
         .swagger-ui-wrap {
@@ -54,7 +53,7 @@
                 supportHeaderParams: false,
                 supportedSubmitMethods: ['get', 'post', 'put'],
                 onComplete: function(swaggerApi, swaggerUi){
-                    $("img[src$='throbber.gif']").attr("src", "{{ STATIC_URL }}tastypie_swagger/images/throbber.gif");
+                    $("img[src$='throbber.gif']").attr("src", "{% static "tastypie_swagger/images/throbber.gif" %}");
                     if(console) {
                         console.log("Loaded SwaggerUI")
                         console.log(swaggerApi);
@@ -84,10 +83,10 @@
 
         <form id='api_selector'>
             <div class='input icon-btn'>
-                <img id="show-pet-store-icon" src="{{ STATIC_URL }}tastypie_swagger/images/pet_store_api.png" title="Show Swagger Petstore Example Apis">
+                <img id="show-pet-store-icon" src="{% static "tastypie_swagger/images/pet_store_api.png" %}" title="Show Swagger Petstore Example Apis">
             </div>
             <div class='input icon-btn'>
-                <img id="show-wordnik-dev-icon" src="{{ STATIC_URL }}tastypie_swagger/images/wordnik_api.png" title="Show Wordnik Developer Apis">
+                <img id="show-wordnik-dev-icon" src="{% static "tastypie_swagger/images/wordnik_api.png" %}" title="Show Wordnik Developer Apis">
             </div>
             <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl"
                                       type="text"/></div>


### PR DESCRIPTION
Now using the `staticfiles` template tag instead of the obsolete `{% load url from future %}` to be compatible with django >= 1.9.