### PR TITLE
Update urls.py to new urlpatterns format

### DIFF
--- a/tastypie_swagger/urls.py
+++ b/tastypie_swagger/urls.py
@@ -5,9 +5,9 @@ except ImportError:
 
 from .views import SwaggerView, ResourcesView, SchemaView
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', SwaggerView.as_view(), name='index'),
     url(r'^resources/$', ResourcesView.as_view(), name='resources'),
     url(r'^schema/(?P<resource>\S+)$', SchemaView.as_view()),
     url(r'^schema/$', SchemaView.as_view(), name='schema'),
-)
+]


### PR DESCRIPTION
```
urlpatterns = patterns('',)
```

Is deprecated as of Django 1.10. I see no reason to not change it now as I tested and it doesn't seem to disrupt the function of the application at all.
