### PR TITLE
Fixed compatibility with Django 1.10

### DIFF
--- a/tastypie_swagger/urls.py
+++ b/tastypie_swagger/urls.py
@@ -1,13 +1,23 @@
 try:
-	from django.conf.urls import patterns, include, url
+    from django.conf.urls import url
 except ImportError:
-	from django.conf.urls.defaults import patterns, include, url
+    from django.conf.urls.defaults import url
 
 from .views import SwaggerView, ResourcesView, SchemaView
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', SwaggerView.as_view(), name='index'),
     url(r'^resources/$', ResourcesView.as_view(), name='resources'),
     url(r'^schema/(?P<resource>\S+)$', SchemaView.as_view()),
-    url(r'^schema/$', SchemaView.as_view(), name='schema'),
-)
+    url(r'^schema/$', SchemaView.as_view(), name='schema')
+]
+
+from django import get_version
+from distutils.version import StrictVersion
+
+if StrictVersion(get_version()) < StrictVersion("1.10"):
+    try:
+        from django.conf.urls import patterns
+    except ImportError:
+        from django.conf.urls.defaults import patterns
+    urlpatterns = patterns('', *urlpatterns)

--- a/tastypie_swagger/urls.py
+++ b/tastypie_swagger/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
 from django import get_version
 from distutils.version import StrictVersion
 
-if StrictVersion(get_version()) < StrictVersion("1.10"):
+if StrictVersion(get_version()) < StrictVersion("1.8"):
     try:
         from django.conf.urls import patterns
     except ImportError:


### PR DESCRIPTION
Based on #116. Fixed `RemovedInDjango110Warning
: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.`. Checked work on Django 1.9 and 1.10.
