### PR TITLE
compatibility with django 2.x

### DIFF
--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -203,17 +203,7 @@ class ResourceSwaggerMapping(object):
                             has_related_resource = hasattr(self.resource.fields[name], 'get_related_resource')
 
                         if not has_related_resource:
-                            #This code has been mostly sucked from the tastypie lib
-                            if getattr(self.resource._meta, 'queryset', None) is not None:
-                                # Get the possible query terms from the current QuerySet.
-                                if hasattr(self.resource._meta.queryset.query.query_terms, 'keys'):
-                                    # Django 1.4 & below compatibility.
-                                    field = self.resource._meta.queryset.query.query_terms.keys()
-                                else:
-                                    # Django 1.5+.
-                                    field = self.resource._meta.queryset.query.query_terms
-                            else:
-                                field = self.resource.fields[name].get_lookups().keys()
+                            field = self.resource.fields[name].get_lookups().keys()
 
                         else: # Show all params from related model
                             # Add a subset of filter only foreign-key compatible on the relation itself.

--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 
-from django.db.models.sql.constants import QUERY_TERMS
 
 try:
     from django.utils.encoding import force_text
@@ -214,12 +213,7 @@ class ResourceSwaggerMapping(object):
                                     # Django 1.5+.
                                     field = self.resource._meta.queryset.query.query_terms
                             else:
-                                if hasattr(QUERY_TERMS, 'keys'):
-                                    # Django 1.4 & below compatibility.
-                                    field = QUERY_TERMS.keys()
-                                else:
-                                    # Django 1.5+.
-                                    field = QUERY_TERMS
+                                field = self.resource.fields[name].get_lookups().keys()
 
                         else: # Show all params from related model
                             # Add a subset of filter only foreign-key compatible on the relation itself.

--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -1,7 +1,13 @@
 import datetime
 import logging
 
-
+#from django.db.models.sql.constants import QUERY_TERMS
+QUERY_TERMS = {
+    'exact', 'iexact', 'contains', 'icontains', 'gt', 'gte', 'lt', 'lte', 'in',
+    'startswith', 'istartswith', 'endswith', 'iendswith', 'range', 'year',
+    'month', 'day', 'week_day', 'hour', 'minute', 'second', 'isnull', 'search',
+    'regex', 'iregex',
+}
 try:
     from django.utils.encoding import force_text
 except ImportError:
@@ -159,7 +165,7 @@ class ResourceSwaggerMapping(object):
             'name': "order_by",
             'dataType': "String",
             'required': False,
-            'description': unicode("Orders the result set based on the selection. "
+            'description': str("Orders the result set based on the selection. "
                                    "Ascending order by default, prepending the '-' "
                                    "sign change the sorting order to descending"),
             'allowableValues': {
@@ -203,7 +209,17 @@ class ResourceSwaggerMapping(object):
                             has_related_resource = hasattr(self.resource.fields[name], 'get_related_resource')
 
                         if not has_related_resource:
-                            field = self.resource.fields[name].get_lookups().keys()
+                            #This code has been mostly sucked from the tastypie lib
+                            if getattr(self.resource._meta, 'queryset', None) is not None:
+                                # Get the possible query terms from the current QuerySet.
+                                field = QUERY_TERMS
+                            else:
+                                if hasattr(QUERY_TERMS, 'keys'):
+                                    # Django 1.4 & below compatibility.
+                                    field = QUERY_TERMS.keys()
+                                else:
+                                    # Django 1.5+.
+                                    field = QUERY_TERMS
 
                         else: # Show all params from related model
                             # Add a subset of filter only foreign-key compatible on the relation itself.
@@ -288,7 +304,7 @@ class ResourceSwaggerMapping(object):
                                   name=name,
                                   dataType=field['dataType'],
                                   required=field['required'],
-                                  description=unicode(field['description'])
+                                  description=str(field['description'])
                                   ))
 
 

--- a/tastypie_swagger/urls.py
+++ b/tastypie_swagger/urls.py
@@ -1,13 +1,18 @@
 try:
-	from django.conf.urls import patterns, include, url
+    from django.urls import  include, re_path as url
 except ImportError:
-	from django.conf.urls.defaults import patterns, include, url
+    try:
+        from django.conf.urls import patterns, include, url
+    except ImportError:
+        from django.conf.urls.defaults import patterns, include, url
 
 from .views import SwaggerView, ResourcesView, SchemaView
 
-urlpatterns = patterns('',
+app_name = 'tastypie_swagger'
+
+urlpatterns = [
     url(r'^$', SwaggerView.as_view(), name='index'),
     url(r'^resources/$', ResourcesView.as_view(), name='resources'),
     url(r'^schema/(?P<resource>\S+)$', SchemaView.as_view()),
     url(r'^schema/$', SchemaView.as_view(), name='schema'),
-)
+]

--- a/tastypie_swagger/views.py
+++ b/tastypie_swagger/views.py
@@ -4,7 +4,10 @@ import json
 from django.views.generic import TemplateView
 from django.http import HttpResponse, Http404
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
 
 import tastypie
 


### PR DESCRIPTION
It's a bit dirty way to make django-tastypie-swagger workin with django 2.x.
